### PR TITLE
Fix: `inotify-tools` is needed to run `file_system` for your system

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
             deps-erl${{ matrix.erlang }}-
       - name: Lint & test
         run: |
+          sudo apt-get install -y --no-install-recommends inotify-tools
           mix "do" local.hex --force, local.rebar --force
           mix "do" deps.get, deps.clean --unused, cotton.lint
           mix coveralls.github


### PR DESCRIPTION
I missed this by `mix cotton.init.github` at https://github.com/cctiger36/config_z/commit/38de93fc104eb5eaa53def00560a40008c6a557c